### PR TITLE
プログレスバーを出力する処理の追加

### DIFF
--- a/src/countLines.ts
+++ b/src/countLines.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+
+/**
+ * @fn
+ * mizarファイルの記述部の行数を返す関数
+ * スペースや改行だけの行は、それ以降に他の記述がなければカウントされない
+ * @param (fileName) 記述部の行数を取得する対象のファイル名
+ * @return 記述部の行数
+ */
+export function countArticleLines(fileName:string):number{
+    let count:number = 0;
+    let result:number = 0;
+    let file = "" + fs.readFileSync(fileName);
+    let fileList = file.split('\r\n'||'\n');
+    let isArticleArea = false;
+    for (let line of fileList){
+        if(line.indexOf('begin') !== -1){
+            isArticleArea = true;
+        }
+        if(isArticleArea){
+            count += 1;
+        }
+        if(/\w+/.test(line)){
+            result = count;
+        }
+    }
+    return result;
+}
+
+/**
+ * @fn
+ * 環境部の行数を返す関数
+ * beginが記述される直前の行数までを返す
+ * @param (fileName) 環境部の行数を取得する対象のファイル名
+ * @return 環境部の行数
+ */
+export function countEnvironmentalLines(fileName:string):number{
+    let count:number = 0;
+    let file = "" + fs.readFileSync(fileName);
+    let fileList = file.split('\r\n'||'\n');
+    for (let line of fileList){
+        if(line.indexOf('begin') !== -1){
+            break;
+        }
+        count++;
+    }
+    return count;
+}

--- a/src/countLines.ts
+++ b/src/countLines.ts
@@ -1,48 +1,39 @@
 import * as fs from "fs";
+import { env } from "vscode";
 
 /**
  * @fn
- * mizarファイルの記述部の行数を返す関数
+ * mizarファイルの環境部・記述部の行数を返す関数
  * スペースや改行だけの行は、それ以降に他の記述がなければカウントされない
  * @param (fileName) 記述部の行数を取得する対象のファイル名
- * @return 記述部の行数
+ * @return 環境部・記述部の行数のリスト
  */
-export function countArticleLines(fileName:string):number{
-    let count:number = 0;
-    let result:number = 0;
+export function countLines(fileName:string):number[]{
+    let articleCounter:number = 0;
+    let environmentalCounter:number = 0;
+    let result:number[] = [];
     let file = "" + fs.readFileSync(fileName);
-    let fileList = file.split('\r\n'||'\n');
+    let lines = file.split('\r\n'||'\n');
     let isArticleArea = false;
-    for (let line of fileList){
+    for (let line of lines){
+        // begin以降から記述部が始まるためisArticleAreaにtrueを設定
         if(line.indexOf('begin') !== -1){
             isArticleArea = true;
         }
+        // 記述部の行数のカウント
         if(isArticleArea){
-            count += 1;
+            articleCounter++;
         }
+        // 環境部の行数のカウント
+        else{
+            environmentalCounter++;
+        }
+        // 改行やスペース以外の記述がある行数までを結果に格納する
+        // つまりアルファベットや数字が記述されている行で最も大きい行数が返され、
+        // それ以降の改行やスペースのみの行はカウントされないことになる
         if(/\w+/.test(line)){
-            result = count;
+            result = [environmentalCounter,articleCounter];
         }
     }
     return result;
-}
-
-/**
- * @fn
- * 環境部の行数を返す関数
- * beginが記述される直前の行数までを返す
- * @param (fileName) 環境部の行数を取得する対象のファイル名
- * @return 環境部の行数
- */
-export function countEnvironmentalLines(fileName:string):number{
-    let count:number = 0;
-    let file = "" + fs.readFileSync(fileName);
-    let fileList = file.split('\r\n'||'\n');
-    for (let line of fileList){
-        if(line.indexOf('begin') !== -1){
-            break;
-        }
-        count++;
-    }
-    return count;
 }

--- a/src/displayProgress.ts
+++ b/src/displayProgress.ts
@@ -19,12 +19,12 @@ function padSpace(str:string, num:number=9){
 /**
  * @fn
  * 進度を示す関数を返す関数。
- * 項目を保存するためのitems[]、出力した数を保存するためのnumberOfOutputを保持
+ * 項目を保存するためのitems[]、出力した数を保存するためのnumberOfProgressを保持
  * @brief 進度を示す関数を返す関数
  */
 export function makeDisplayProgress(){
     // 出力している#の数を保存する変数
-    let numberOfOutput:number = 0;
+    let numberOfProgress:number = 0;
     // 出力から得た項目(Parser,MSM等)が「コマンドを実行してから初めて得た項目なのか」を判定するために使うリスト
     // コマンドの実行ごとに空リストから始まり、Parser,MSM,Analyzer等の取得した項目をpushする
     let items:string[] = [];
@@ -34,14 +34,14 @@ export function makeDisplayProgress(){
      * プログラムの出力を受け取り、その進度を示す関数
      * @param (channel) 出力するためのチャンネル
      * @param (line) プログラムが出力した1行
-     * @param (numberOfArticleLines) mizarのarticle部の行数
-     * @param (numberOfBeginLine) mizarのarticle部が始まる前の行番号
+     * @param (numberOfArticleLines) mizarの記述部の行数
+     * @param (numberOfEnvironmentalLines) mizarの環境部の行数
      */
     function _displayProgress(
         channel:vscode.OutputChannel,
         line:string,
         numberOfArticleLines:number,
-        numberOfBeginLine:number
+        numberOfEnvironmentalLines:number
     ):number
     {
         // REVIEW:正規表現が正しいか確認
@@ -49,13 +49,13 @@ export function makeDisplayProgress(){
         // 「Parser」や「3482」にあたる部分をグループ化している
         let matched = line.match(/^(\w+) +\[ *(\d+) *\**\d*\].*$/);
         if(matched === null){
-            return numberOfOutput;
+            return numberOfProgress;
         }
         // 実行して初めて得た項目であった時の前処理
         if (items.indexOf(matched[1],0) === -1){
             if(items.length !== 0){
                 // 直前の項目の#が50未満であれば、足りない分を#で補完
-                for (let i = 0; i < 50 - numberOfOutput; i++){
+                for (let i = 0; i < 50 - numberOfProgress; i++){
                     channel.append("#");
                 }
                 channel.appendLine("");
@@ -65,20 +65,20 @@ export function makeDisplayProgress(){
             channel.append(item +':');
             // 前処理を終えた項目として、itemsにpush
             items.push(matched[1]);
-            numberOfOutput = 0;
+            numberOfProgress = 0;
         }
         // 現在の進度と、出力のバーの差を計算する
-        let progress = (Number(matched[2]) - numberOfBeginLine) 
-                        / numberOfArticleLines * 50 - numberOfOutput;
+        let progressDiff = (Number(matched[2]) - numberOfEnvironmentalLines) 
+                        / numberOfArticleLines * 50 - numberOfProgress;
         // 「現在の進度-出力している進度」の差を埋める出力処理
-        for (let i = 0; i < Math.floor(progress); i++){
-            if (numberOfOutput >= 50){
+        for (let i = 0; i < Math.floor(progressDiff); i++){
+            if (numberOfProgress >= 50){
                 break;
             }
             channel.append("#");
-            numberOfOutput += 1;
+            numberOfProgress += 1;
         }
-        return numberOfOutput;
+        return numberOfProgress;
     }
     return _displayProgress;
 }

--- a/src/displayProgress.ts
+++ b/src/displayProgress.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+
+/**
+ * @fn
+ * 項目を横並びにするために文字列の後にスペースを追加する関数
+ * 指定文字数までスペースを追加する
+ * @param (str) スペースを追加する文字列
+ * @param (num) 何文字までスペースを追加するかを指定する数
+ * @return num文字までスペースを追加した文字列
+ */
+function padSpace(str:string, num:number=9){
+    let padding = str;
+    for (let i = 0; i < num - str.length; i++){
+        padding = padding + " ";
+    }
+    return padding;
+}
+
+/**
+ * @fn
+ * 進度を示す関数を返す関数。
+ * 項目を保存するためのitems[]、出力した数を保存するためのnumberOfOutputを保持
+ * @brief 進度を示す関数を返す関数
+ */
+export function makeDisplayProgress(){
+    // 出力している#の数を保存する変数
+    let numberOfOutput:number = 0;
+    // 出力から得た項目(Parser,MSM等)が「コマンドを実行してから初めて得た項目なのか」を判定するために使うリスト
+    // コマンドの実行ごとに空リストから始まり、Parser,MSM,Analyzer等の取得した項目をpushする
+    let items:string[] = [];
+
+    /**
+     * @fn
+     * プログラムの出力を受け取り、その進度を示す関数
+     * @param (channel) 出力するためのチャンネル
+     * @param (line) プログラムが出力した1行
+     * @param (numberOfArticleLines) mizarのarticle部の行数
+     * @param (numberOfBeginLine) mizarのarticle部が始まる前の行番号
+     */
+    function _displayProgress(
+        channel:vscode.OutputChannel,
+        line:string,
+        numberOfArticleLines:number,
+        numberOfBeginLine:number
+    ):number
+    {
+        // REVIEW:正規表現が正しいか確認
+        // Parser   [3482] などを正規表現として抜き出し、
+        // 「Parser」や「3482」にあたる部分をグループ化している
+        let matched = line.match(/^(\w+) +\[ *(\d+) *\**\d*\].*$/);
+        if(matched === null){
+            return numberOfOutput;
+        }
+        // 実行して初めて得た項目であった時の前処理
+        if (items.indexOf(matched[1],0) === -1){
+            if(items.length !== 0){
+                // 直前の項目の#が50未満であれば、足りない分を#で補完
+                for (let i = 0; i < 50 - numberOfOutput; i++){
+                    channel.append("#");
+                }
+                channel.appendLine("");
+            }
+            // 出力の項目を横並びにするために、スペースを補完する
+            let item = padSpace(matched[1]);
+            channel.append(item +':');
+            // 前処理を終えた項目として、itemsにpush
+            items.push(matched[1]);
+            numberOfOutput = 0;
+        }
+        // 現在の進度と、出力のバーの差を計算する
+        let progress = (Number(matched[2]) - numberOfBeginLine) 
+                        / numberOfArticleLines * 50 - numberOfOutput;
+        // 「現在の進度-出力している進度」の差を埋める出力処理
+        for (let i = 0; i < Math.floor(progress); i++){
+            if (numberOfOutput >= 50){
+                break;
+            }
+            channel.append("#");
+            numberOfOutput += 1;
+        }
+        return numberOfOutput;
+    }
+    return _displayProgress;
+}

--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { makeDisplayProgress } from './displayProgress';
+import { countArticleLines,countEnvironmentalLines } from './countLines';
 
 const carrier = require('carrier');
 const Makeenv = "makeenv";
@@ -35,6 +37,8 @@ export async function mizar_verify(
     channel.clear();
     channel.show();
 
+    const displayProgress = makeDisplayProgress();
+
     //makeenvの実行
     let makeenvProcess = require('child_process').spawn(makeenv,[fileName]);
     
@@ -53,25 +57,30 @@ export async function mizar_verify(
     let result = new Promise((resolve) => {
 
         makeenvProcess.on('close', () => {
-
+            channel.appendLine("Running " + path.basename(util) + " on " + fileName + '\n');
+            channel.appendLine("   Start |------------------------------------------------->| End");
             if(!isMakeenvSuccess){
                 resolve('makeenv error');
                 return;
             }
-
-            //verifierを実行し、コロンのある行を逐次出力チャンネルに追加
+            let numberOfArticleLines:number = countArticleLines(fileName);
+            let numberOfBeginLine:number = countEnvironmentalLines(fileName); 
+            let numberOfOutput:number = 0;
             let verifierProcess = require('child_process').spawn(util,[fileName]);
             carrier.carry(verifierProcess.stdout, (line:string) => {
-                if(line.indexOf(':') !== -1){
-                    channel.appendLine(line);
-                }
+                // lineを渡してプログレスバーを表示する関数を呼び出す
+                numberOfOutput = displayProgress(channel,line,numberOfArticleLines,numberOfBeginLine);
                 if(line.indexOf('*') !== -1){
                     isVerifierSuccess = false;
                 }
             }, null, /\r/);
 
             verifierProcess.on('close',() => {
-
+                // 最後の項目のプログレスバーが50未満であれば、足りない分を補完
+                for(let i = 0; i < 50 - numberOfOutput; i++){
+                    channel.append('#');
+                }
+                channel.appendLine("\n\nEnd.");
                 if (!isVerifierSuccess){
                     resolve('verifier error');
                 }


### PR DESCRIPTION
プログレスバーの出力処理を追加しました。
新しい項目を取得したとき、その前の項目のプログレスバーがすべて満たされていなければ、不足分を補って出力する処理を記述しました。（例えばParserの出力が不足していても、MSMを得たらParserは完了したとみなし、不足分を補える）
しかし最後の項目ではそれができず、ファイルmizarFunctions.tsの80行目に同じ処理(for文の処理)を記述したことが気がかりです。

この記述がなければ,（バーの最大出力数を10としたとき）

`Parser:##########`→(10個出力されているのでOK)
`MSM:##########`→(10個出力されているのでOK)
`Analyzer:##########`→(10個出力されているのでOK)
`Checker:#########`→(9個しか出力されていないのでNG)

のような状況になる場合があります。