### PR TITLE
makeenvの出力方法を修正

### DIFF
--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -40,7 +40,14 @@ export async function mizar_verify(
     let isMakeenvSuccess = true;
     let isCommandSuccess = true;
     carrier.carry(makeenvProcess.stdout, (line:string) => {
-        channel.appendLine(line);
+        // -Vocabularies
+        // -Vocabularies  [ 22]
+        // -Requirements
+        // -Requirements  [ 34]
+        // 上記のような記述は出力しないようにする
+        if(!/^-/.test(line)){
+            channel.appendLine(line);
+        }
         if (line.indexOf('*') !== -1){
             isMakeenvSuccess = false;
         }


### PR DESCRIPTION
Mizarファイルの環境部に変更があり、makeenvを実行すると

![output2](https://user-images.githubusercontent.com/32231297/69939938-61151900-1524-11ea-828b-e0299402942d.png)

上記の画像のような出力がされるのですが
「環境部の項目名とその終わりの行数を表示しているだけ」
「毎回表示されるわけではない」
「emacsの方ではこれらを出力していない」
といった理由から「そもそも不要なのではないか」と判断し、これらを出力しないようにしました。

そうすることで出力は常に以下の画像のようになります。

![output](https://user-images.githubusercontent.com/32231297/69939533-6de53d00-1523-11ea-9e79-5f20c2c674b9.png)