### PR TITLE
Close #37 エラーの有無をOutputに書き出す

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mizar-extension",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mizar-extension",
-	"version": "0.0.4",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mizar-extension",
     "displayName": "Mizar extension",
     "description": "An extension for VS Code which provides support for the Mizar language.",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "publisher": "fpsbpkm",
     "engines": {
         "vscode": "^1.38.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mizar-extension",
     "displayName": "Mizar extension",
     "description": "An extension for VS Code which provides support for the Mizar language.",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "fpsbpkm",
     "engines": {
         "vscode": "^1.38.0"

--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -88,6 +88,9 @@ export async function mizar_verify(
                     channel.appendLine(" *" + numberOfErrors);
                     channel.append("\n**** " + numberOfErrors + " error detected.");
                 }
+                else{
+                    channel.append("\n\n**** There are not any errors.");
+                }
                 channel.appendLine("\n\nEnd.\n");
                 if (!isCommandSuccess){
                     resolve('command error');

--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -80,8 +80,13 @@ export async function mizar_verify(
                 let appendChunk = "#".repeat(MAX_OUTPUT-numberOfProgress);
                 channel.append(appendChunk);
                 // エラーがあれば、その数を出力
-                if(numberOfErrors){
-                    channel.append(" *" + numberOfErrors);
+                if(numberOfErrors > 1){
+                    channel.appendLine(" *" + numberOfErrors);
+                    channel.append("\n**** " + numberOfErrors + " errors detected.");
+                }
+                else if(numberOfErrors === 1){
+                    channel.appendLine(" *" + numberOfErrors);
+                    channel.append("\n**** " + numberOfErrors + " error detected.");
                 }
                 channel.appendLine("\n\nEnd.\n");
                 if (!isCommandSuccess){

--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -79,7 +79,7 @@ export async function mizar_verify(
                 // 最後の項目のプログレスバーがMAX_OUTPUT未満であれば、足りない分を補完
                 let appendChunk = "#".repeat(MAX_OUTPUT-numberOfProgress);
                 channel.append(appendChunk);
-                // エラーがあれば、その数を出力
+                // エラーの有無を出力
                 if(numberOfErrors > 1){
                     channel.appendLine(" *" + numberOfErrors);
                     channel.append("\n**** " + numberOfErrors + " errors detected.");


### PR DESCRIPTION
エラーの有無のメッセージを表示する処理を追加しました。
エラーが1つの時に「errors」と出力することが嫌だったため、エラーが1つだけの場合と、それより多い場合で場合分けしました。