### PR TITLE
Close #9 ホバー表示機能の実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "onCommand:mizar-reliters",
         "onCommand:mizar-relprem",
         "onCommand:mizar-irrvoc",
-        "onCommand:mizar-inacc"
+        "onCommand:mizar-inacc",
+        "onLanguage:Mizar"
     ],
     "main": "./out/extension.js",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { mizar_verify, mizfiles } from './mizarFunctions';
 import { makeQueryFunction } from './mizarMessages';
 import { displayErrorLinks } from './displayErrors';
+import { HoverProvider } from './hover';
 
 export const queryMizarMsg = makeQueryFunction();
 
@@ -136,6 +137,9 @@ export function activate(context: vscode.ExtensionContext) {
         )
     );
 
+    let hover = new HoverProvider();
+    let disposable10 = vscode.languages.registerHoverProvider({scheme: 'file', language: 'Mizar'}, hover);
+
     context.subscriptions.push(disposable1);
     context.subscriptions.push(disposable2);
     context.subscriptions.push(disposable3);
@@ -145,6 +149,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(disposable7);
     context.subscriptions.push(disposable8);
     context.subscriptions.push(disposable9);
+    context.subscriptions.push(disposable10);
 }
 
 // this method is called when your extension is deactivated

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -23,7 +23,6 @@ function getNthKeywordIndex(text:string,keyword:RegExp,n:number){
     }
     return absoluteIndex;
 }
-// TODO:positionが不要
 /**
  * 開いているテキスト内のホバーの情報を抽出して返す関数
  * @param document ホバーしているドキュメント（ファイル）
@@ -33,8 +32,7 @@ function getNthKeywordIndex(text:string,keyword:RegExp,n:number){
  */
 function returnHover(
     document:vscode.TextDocument,
-    wordRange:vscode.Range,
-    position:vscode.Position
+    wordRange:vscode.Range
 ){
     let hoverInformation:Promise<vscode.Hover> = new Promise(
     (resolve,reject) => {
@@ -72,7 +70,7 @@ function returnHover(
                 let number = getNthKeywordIndex(
                     referenceText,
                     /\r\n/, 
-                    position.line
+                    wordRange.start.line
                 );
                 // 直前のラベルの定義元の位置を取得
                 startIndex = referenceText.lastIndexOf(
@@ -118,11 +116,13 @@ function returnMMLHover(
         let startIndex = 0,endIndex = 0;
         let hoveredWord = document.getText(wordRange);
         let [fileName, referenceWord] = hoveredWord.split(':');
+        // .absのファイルを参照する
         fileName = path.join(mmlPath,fileName.toLowerCase() + '.abs');
         fs.readFile(fileName,'utf8', (err,referenceText) => {
             if(err){
                 reject(err);
             }
+            // hoveredWordは.absファイルで一意のキーになるため、インデックスを取得する
             let wordIndex = referenceText.indexOf(hoveredWord);
             // definitionを参照する場合
             if (/def \d/.test(referenceWord)){
@@ -183,7 +183,7 @@ export class HoverProvider implements vscode.HoverProvider{
         // 「Def10」「Th1」「 A1」「,A2」等を正規表現で取得する
         if (wordRange = document.getWordRangeAtPosition(
                         position,/(Def\d+|Th\d+|( |,)(A|Lm)\d+)/) ){
-            return returnHover(document, wordRange, position);
+            return returnHover(document, wordRange);
         }
         // 外部ファイル（MML）の定義、定理、スキームを参照する場合
         // 「FUNCT_2:def 1」「FINSUB_1:13」「XBOOLE_0:sch 1」等を正規表現で取得する

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,80 +1,85 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-
-function indexOfNumber(allText:string,search:string,number:number){
+// n番目のsearchStringの位置を返す関数
+function indexOfNumber(text:string,searchString:string,n:number){
     var index = -1;
-    for(let i = 0; i < number; i++){
-        index = allText.indexOf(search,index+1);
+    for(let i = 0; i < n; i++){
+        index = text.indexOf(searchString,index+1);
     }
     return index;
 }
 
-function returnExternalFileHover(word:string, wordRange:vscode.Range, fileName:string, numberOfreference:string){
+function returnHover(document:vscode.TextDocument, wordRange:vscode.Range, position:vscode.Position){
     try{
-        let start = 0,end = 0;
+        let startIndex = 0,endIndex = 0;
         // TODO:非同期へ修正
-        let textOfReference = "" + fs.readFileSync(fileName);
-
-        // 場合に応じて、それぞれ参照箇所を抽出する
-
+        let textOfReference = "" + fs.readFileSync(document.fileName);
+        let word = document.getText(wordRange);
         // definitionを参照する場合
-        if(word.indexOf('def') >= 0){
-            start = indexOfNumber(textOfReference, 'definition', Number(numberOfreference.slice('def '.length))+1);
-            end = start + textOfReference.slice(start).search(/\nend;/g) + '\nend;'.length;
-        }
-        // schemeを参照する場合
-        else if(word.indexOf('sch') >= 0){
-            start = indexOfNumber(textOfReference, 'scheme', Number(numberOfreference.slice('sch '.length))+1);
-            end = start + textOfReference.slice(start).search(/\nend;/g) + '\nend;'.length;
-        }
-        // theoremを参照する場合
-        else{
-            start = indexOfNumber(textOfReference, 'theorem', Number(numberOfreference)+1);
-            end = start + textOfReference.slice(start).search(/(\nproof|;)/g) + '\n'.length;
-        }
-
-        let markedString = {language:"Mizar", value: textOfReference.slice(start,end)};
-        let hover = new vscode.Hover(markedString, wordRange);
-        return hover;
-    }catch(e){
-        console.log(e);
-        vscode.window.showErrorMessage("Can't open " + fileName + '!!!');
-        return;
-    }
-}
-
-function returnInternalFileHover(word:string, wordRange:vscode.Range, fileName:string, position:vscode.Position){
-    let start = 0,end = 0;
-    // TODO:非同期へ修正
-    let textOfReference = "" + fs.readFileSync(fileName);
-    try{
-        // definitionを参照する場合
-        if(word.indexOf('Def') >= 0){
+        if(word.indexOf('Def') > -1){
             // TODO:+1の修正、見直し
-            start = indexOfNumber(textOfReference, 'definition', Number(word.slice('Def'.length))+1);
-            end = start + textOfReference.slice(start).search(/\nend;/g) + '\nend;'.length;
+            startIndex = indexOfNumber(textOfReference, 'definition', Number(word.slice('Def'.length))+1);
+            endIndex = startIndex + textOfReference.slice(startIndex).search(/\nend;/g) + '\nend;'.length;
         }
         // theoremを参照する場合
-        else if(word.indexOf('Th') >= 0){
-            start = indexOfNumber(textOfReference, 'theorem', Number(word.slice('Th'.length))+1);
-            end = start + textOfReference.slice(start).search(/(\nproof|;)/g) + '\n'.length;
+        else if(word.indexOf('Th') > -1){
+            startIndex = indexOfNumber(textOfReference, 'theorem', Number(word.slice('Th'.length))+1);
+            endIndex = startIndex + textOfReference.slice(startIndex).search(/(\nproof|;)/g) + '\n'.length;
         }
         // ラベルを参照する場合
         else{
             // ホバー中の現在の行までの文字数を取得
             let number = indexOfNumber(textOfReference,'\n', position.line);
             // 直前のラベルの定義元の位置を取得
-            start = textOfReference.lastIndexOf(word+':', number);
-            end = start + textOfReference.slice(start).indexOf('\n');
+            startIndex = textOfReference.lastIndexOf(word.replace(/( |,)/, '')+':', number);
+            endIndex = startIndex + textOfReference.slice(startIndex).indexOf('\n');
             
         }
 
-        let markedString = {language:"Mizar", value: textOfReference.slice(start,end)};
+        let markedString = {language:"Mizar", value: textOfReference.slice(startIndex,endIndex)};
         let hover = new vscode.Hover(markedString, wordRange);
         return hover;
 
     }catch(e){
+        return;
+    }
+}
+
+function returnMMLHover(document:vscode.TextDocument,wordRange:vscode.Range):vscode.ProviderResult<vscode.Hover>{
+    if(process.env.MIZFILES === undefined){
+        vscode.window.showErrorMessage('error!');
+        return;
+    }
+    try{
+        let mmlPath = path.join(process.env.MIZFILES,'mml');
+        let word = document.getText(wordRange);
+        let [fileName, referenceWord] = word.split(':');
+        fileName = path.join(mmlPath,fileName.toLowerCase() + '.miz');
+        let startIndex = 0,endIndex = 0;
+        // TODO:非同期へ修正
+        let referenceText = "" + fs.readFileSync(fileName)
+            // definitionを参照する場合
+            if(referenceWord.indexOf('def') > -1){
+                startIndex = indexOfNumber(referenceText, 'definition', Number(referenceWord.slice('def '.length))+1);
+                endIndex = startIndex + referenceText.slice(startIndex).search(/\nend;/g) + '\nend;'.length;
+            }
+            // schemeを参照する場合
+            else if(referenceWord.indexOf('sch') > -1){
+                startIndex = indexOfNumber(referenceText, 'scheme', Number(referenceWord.slice('sch '.length))+1);
+                endIndex = startIndex + referenceText.slice(startIndex).search(/\nend;/g) + '\nend;'.length;
+            }
+            // theoremを参照する場合
+            else{
+                startIndex = indexOfNumber(referenceText, 'theorem', Number(referenceWord)+1);
+                endIndex = startIndex + referenceText.slice(startIndex).search(/(\nproof|;)/g) + '\n'.length;
+            }
+            let markedString = {language:"Mizar", value: referenceText.slice(startIndex,endIndex)};
+            let hover = new vscode.Hover(markedString, wordRange);
+            return hover;
+    }catch(e){
+        console.log(e);
+        vscode.window.showErrorMessage("Can't open file!");
         return;
     }
 }
@@ -86,35 +91,22 @@ export class HoverProvider implements vscode.HoverProvider{
         position: vscode.Position,
         token:vscode.CancellationToken
     ):vscode.ProviderResult<vscode.Hover>{
-
-        if(process.env.MIZFILES === undefined){
-            vscode.window.showErrorMessage('error!');
-            return;
-        }
-
         // ホバーの範囲を正規表現により取得
-        let wordRange = document.getWordRangeAtPosition(position,/(\w+:def \d+|\w+:sch \d+|\w+:\d+)/);
-        let word = document.getText(wordRange);
+        let wordRange;
 
-        // 現在開いているファイルの定義、定理を参照する場合
-        if(wordRange === undefined){
-            let fileName = document.fileName;
-            let wordRange = document.getWordRangeAtPosition(position,/(Def\d+|Th\d+|A\d+)/);
-            let word = document.getText(wordRange);
-            if (wordRange === undefined){
-                return;
-            }
-            let hover = returnInternalFileHover(word, wordRange, fileName, position);
-            return hover;
+        // 自身のファイル内の定義、定理、ラベルを参照する場合
+        // 「Def10」「Th1」「 A1」「,A2」等を正規表現で取得する
+        if (wordRange = document.getWordRangeAtPosition(position,/(Def\d+|Th\d+|( |,)A\d+)/)){
+            return returnHover(document, wordRange, position);
         }
         // 外部ファイル（MML）の定義、定理、スキームを参照する場合
+        // 「FUNCT_2:def 1」「FINSUB_1:13」「XBOOLE_0:sch 1」等を正規表現で取得する
+        else if (wordRange = document.getWordRangeAtPosition(position,/(\w+:def \d+|\w+:\d+|\w+:sch \d+)/)){
+            return returnMMLHover(document,wordRange);
+        }
+        // ホバー対象のキーワードでない場合
         else{
-            let mmlPath = path.join(process.env.MIZFILES,'mml');
-            let [fileName, numberOfreference] = word.split(':');
-            fileName = path.join(mmlPath,fileName.toLowerCase() + '.miz');
-            // 外部ファイルから適切なホバー情報を取得する
-            let hover = returnExternalFileHover(word, wordRange, fileName, numberOfreference);
-            return hover;
+            return;
         }
     }
 }

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -23,6 +23,7 @@ function getNthKeywordIndex(text:string,keyword:RegExp,n:number){
     }
     return absoluteIndex;
 }
+
 /**
  * 開いているテキスト内のホバーの情報を抽出して返す関数
  * @param document ホバーしているドキュメント（ファイル）
@@ -165,7 +166,6 @@ function returnMMLHover(
 /**
  * ホバーを提供するクラス
  * @constructor
- * @param 
  */
 export class HoverProvider implements vscode.HoverProvider{
     /**

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,0 +1,120 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+function indexOfNumber(allText:string,search:string,number:number){
+    var index = -1;
+    for(let i = 0; i < number; i++){
+        index = allText.indexOf(search,index+1);
+    }
+    return index;
+}
+
+function returnExternalFileHover(word:string, wordRange:vscode.Range, fileName:string, numberOfreference:string){
+    try{
+        let start = 0,end = 0;
+        // TODO:非同期へ修正
+        let textOfReference = "" + fs.readFileSync(fileName);
+
+        // 場合に応じて、それぞれ参照箇所を抽出する
+
+        // definitionを参照する場合
+        if(word.indexOf('def') >= 0){
+            start = indexOfNumber(textOfReference, 'definition', Number(numberOfreference.slice('def '.length))+1);
+            end = start + textOfReference.slice(start).search(/\nend;/g) + '\nend;'.length;
+        }
+        // schemeを参照する場合
+        else if(word.indexOf('sch') >= 0){
+            start = indexOfNumber(textOfReference, 'scheme', Number(numberOfreference.slice('sch '.length))+1);
+            end = start + textOfReference.slice(start).search(/\nend;/g) + '\nend;'.length;
+        }
+        // theoremを参照する場合
+        else{
+            start = indexOfNumber(textOfReference, 'theorem', Number(numberOfreference)+1);
+            end = start + textOfReference.slice(start).search(/(\nproof|;)/g) + '\n'.length;
+        }
+
+        let markedString = {language:"Mizar", value: textOfReference.slice(start,end)};
+        let hover = new vscode.Hover(markedString, wordRange);
+        return hover;
+    }catch(e){
+        console.log(e);
+        vscode.window.showErrorMessage("Can't open " + fileName + '!!!');
+        return;
+    }
+}
+
+function returnInternalFileHover(word:string, wordRange:vscode.Range, fileName:string, position:vscode.Position){
+    let start = 0,end = 0;
+    // TODO:非同期へ修正
+    let textOfReference = "" + fs.readFileSync(fileName);
+    try{
+        // definitionを参照する場合
+        if(word.indexOf('Def') >= 0){
+            // TODO:+1の修正、見直し
+            start = indexOfNumber(textOfReference, 'definition', Number(word.slice('Def'.length))+1);
+            end = start + textOfReference.slice(start).search(/\nend;/g) + '\nend;'.length;
+        }
+        // theoremを参照する場合
+        else if(word.indexOf('Th') >= 0){
+            start = indexOfNumber(textOfReference, 'theorem', Number(word.slice('Th'.length))+1);
+            end = start + textOfReference.slice(start).search(/(\nproof|;)/g) + '\n'.length;
+        }
+        // ラベルを参照する場合
+        else{
+            // ホバー中の現在の行までの文字数を取得
+            let number = indexOfNumber(textOfReference,'\n', position.line);
+            // 直前のラベルの定義元の位置を取得
+            start = textOfReference.lastIndexOf(word+':', number);
+            end = start + textOfReference.slice(start).indexOf('\n');
+            
+        }
+
+        let markedString = {language:"Mizar", value: textOfReference.slice(start,end)};
+        let hover = new vscode.Hover(markedString, wordRange);
+        return hover;
+
+    }catch(e){
+        return;
+    }
+}
+
+export class HoverProvider implements vscode.HoverProvider{
+    // ホバーするたびに呼び出されるメソッド
+    public provideHover(
+        document:vscode.TextDocument,
+        position: vscode.Position,
+        token:vscode.CancellationToken
+    ):vscode.ProviderResult<vscode.Hover>{
+
+        if(process.env.MIZFILES === undefined){
+            vscode.window.showErrorMessage('error!');
+            return;
+        }
+
+        // ホバーの範囲を正規表現により取得
+        let wordRange = document.getWordRangeAtPosition(position,/(\w+:def \d+|\w+:sch \d+|\w+:\d+)/);
+        let word = document.getText(wordRange);
+
+        // 現在開いているファイルの定義、定理を参照する場合
+        if(wordRange === undefined){
+            let fileName = document.fileName;
+            let wordRange = document.getWordRangeAtPosition(position,/(Def\d+|Th\d+|A\d+)/);
+            let word = document.getText(wordRange);
+            if (wordRange === undefined){
+                return;
+            }
+            let hover = returnInternalFileHover(word, wordRange, fileName, position);
+            return hover;
+        }
+        // 外部ファイル（MML）の定義、定理、スキームを参照する場合
+        else{
+            let mmlPath = path.join(process.env.MIZFILES,'mml');
+            let [fileName, numberOfreference] = word.split(':');
+            fileName = path.join(mmlPath,fileName.toLowerCase() + '.miz');
+            // 外部ファイルから適切なホバー情報を取得する
+            let hover = returnExternalFileHover(word, wordRange, fileName, numberOfreference);
+            return hover;
+        }
+    }
+}

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -17,7 +17,7 @@ function getNthKeywordIndex(text:string,keyword:RegExp,n:number){
     }
     return absoluteIndex;
 }
-
+// TODO:returnMMLHoverと統合しても良さそう
 function returnHover(
     document:vscode.TextDocument,
     wordRange:vscode.Range,
@@ -26,56 +26,55 @@ function returnHover(
     let p:Promise<vscode.Hover> = new Promise((resolve,reject) => {
         let startIndex = 0,endIndex = 0;
         let hoveredWord = document.getText(wordRange);
-        try{
-            fs.readFile(document.fileName,'utf8',(err,referenceText) => {
-                // definitionを参照する場合
-                if(hoveredWord.indexOf('Def') > -1){
-                    // TODO:+1の修正、見直し
-                    startIndex = getNthKeywordIndex(
-                        referenceText,
-                        /definition( |\r\n)/, 
-                        Number(hoveredWord.slice('Def'.length))
-                    );
-                    endIndex = startIndex 
-                            + referenceText.slice(startIndex).search(/\nend;/g)
-                            + '\nend;'.length;
-                }
-                // theoremを参照する場合
-                else if(hoveredWord.indexOf('Th') > -1){
-                    startIndex = getNthKeywordIndex(
-                        referenceText, 
-                        /theorem( |\r\n)/, 
-                        Number(hoveredWord.slice('Th'.length))
-                    );
-                    endIndex = startIndex 
-                            + referenceText.slice(startIndex).search(/(\nproof|;)/g)
-                            + '\n'.length;
-                }
-                // ラベルを参照する場合
-                else{
-                    // ホバー中の行までの文字数を取得
-                    let number = getNthKeywordIndex(
-                        referenceText,
-                        /\r\n/, 
-                        position.line
-                    );
-                    // 直前のラベルの定義元の位置を取得
-                    startIndex = referenceText.lastIndexOf(
-                        hoveredWord.replace(/( |,)/, '')+':', 
-                        number
-                    );
-                    endIndex = startIndex 
-                            + referenceText.slice(startIndex).indexOf('\n');
-                }
-                let markedString = {
-                    language:"Mizar", 
-                    value: referenceText.slice(startIndex,endIndex)
-                };
-                resolve(new vscode.Hover(markedString, wordRange));
-            });
-        }catch(e){
-            reject(e);
-        }
+        fs.readFile(document.fileName,'utf8',(err,referenceText) => {
+            if(err){
+                reject(err);
+            }
+            // definitionを参照する場合
+            if(hoveredWord.indexOf('Def') > -1){
+                // TODO:+1の修正、見直し
+                startIndex = getNthKeywordIndex(
+                    referenceText,
+                    /definition( |\r\n)/, 
+                    Number(hoveredWord.slice('Def'.length))
+                );
+                endIndex = startIndex 
+                        + referenceText.slice(startIndex).search(/\nend;/g)
+                        + '\nend;'.length;
+            }
+            // theoremを参照する場合
+            else if(hoveredWord.indexOf('Th') > -1){
+                startIndex = getNthKeywordIndex(
+                    referenceText, 
+                    /theorem( |\r\n)/, 
+                    Number(hoveredWord.slice('Th'.length))
+                );
+                endIndex = startIndex 
+                        + referenceText.slice(startIndex).search(/(\nproof|;)/g)
+                        + '\n'.length;
+            }
+            // ラベルを参照する場合
+            else{
+                // ホバー中の行までの文字数を取得
+                let number = getNthKeywordIndex(
+                    referenceText,
+                    /\r\n/, 
+                    position.line
+                );
+                // 直前のラベルの定義元の位置を取得
+                startIndex = referenceText.lastIndexOf(
+                    hoveredWord.replace(/( |,)/, '')+':', 
+                    number
+                );
+                endIndex = startIndex 
+                        + referenceText.slice(startIndex).indexOf('\n');
+            }
+            let markedString = {
+                language:"Mizar", 
+                value: referenceText.slice(startIndex,endIndex)
+            };
+            resolve(new vscode.Hover(markedString, wordRange));
+        });
     });
     return p;
 }
@@ -88,7 +87,9 @@ function returnMMLHover(
     if(process.env.MIZFILES === undefined){
         vscode.window.showErrorMessage('error!');
         return new Promise((resolve,reject) => {
-            reject(new Error('You have to set environment variable "MIZFILES"'));
+            reject(
+                new Error('You have to set environment variable "MIZFILES"')
+            );
         });
     }
     let mmlPath = path.join(process.env.MIZFILES,'mml');
@@ -98,50 +99,49 @@ function returnMMLHover(
     let startIndex = 0,endIndex = 0;
 
     let p:Promise<vscode.Hover> = new Promise ( (resolve, reject)=> {
-        try{
-            fs.readFile(fileName,'utf8', (err,referenceText) => {
-                // definitionを参照する場合
-                if(referenceWord.indexOf('def') > -1){
-                    startIndex = getNthKeywordIndex(
-                        referenceText, 
-                        /definition( |\r\n)/, 
-                        Number(referenceWord.slice('def '.length))
-                    );
-                    endIndex = startIndex 
-                        + referenceText.slice(startIndex).search(/\nend;/g) 
-                        + '\nend;'.length;
-                }
-                // schemeを参照する場合
-                else if(referenceWord.indexOf('sch') > -1){
-                    startIndex = getNthKeywordIndex(
-                        referenceText, 
-                        /scheme( |\r\n)/, 
-                        Number(referenceWord.slice('sch '.length))
-                    );
-                    endIndex = startIndex 
-                        + referenceText.slice(startIndex).search(/\nend;/g) 
-                        + '\nend;'.length;
-                }
-                // theoremを参照する場合
-                else{
-                    startIndex = getNthKeywordIndex(
-                        referenceText, 
-                        /theorem( |\r\n)/, 
-                        Number(referenceWord)
-                    );
-                    endIndex = startIndex 
-                            + referenceText.slice(startIndex).search(/(\nproof|;)/g)
-                            + '\n'.length;
-                }
-                let markedString = {
-                    language:"Mizar", 
-                    value: referenceText.slice(startIndex,endIndex)
-                };
-                resolve(new vscode.Hover(markedString, wordRange));
-            });
-        }catch(e){
-            reject(e);
-        }
+        fs.readFile(fileName,'utf8', (err,referenceText) => {
+            if(err){
+                reject(err);
+            }
+            // definitionを参照する場合
+            if(referenceWord.indexOf('def') > -1){
+                startIndex = getNthKeywordIndex(
+                    referenceText, 
+                    /definition( |\r\n)/, 
+                    Number(referenceWord.slice('def '.length))
+                );
+                endIndex = startIndex 
+                    + referenceText.slice(startIndex).search(/\nend;/g) 
+                    + '\nend;'.length;
+            }
+            // schemeを参照する場合
+            else if(referenceWord.indexOf('sch') > -1){
+                startIndex = getNthKeywordIndex(
+                    referenceText, 
+                    /scheme( |\r\n)/, 
+                    Number(referenceWord.slice('sch '.length))
+                );
+                endIndex = startIndex 
+                    + referenceText.slice(startIndex).search(/\nend;/g) 
+                    + '\nend;'.length;
+            }
+            // theoremを参照する場合
+            else{
+                startIndex = getNthKeywordIndex(
+                    referenceText, 
+                    /theorem( |\r\n)/, 
+                    Number(referenceWord)
+                );
+                endIndex = startIndex 
+                        + referenceText.slice(startIndex).search(/(\nproof|;)/g)
+                        + '\n'.length;
+            }
+            let markedString = {
+                language:"Mizar", 
+                value: referenceText.slice(startIndex,endIndex)
+            };
+            resolve(new vscode.Hover(markedString, wordRange));
+        });
     });
     return p;
 }
@@ -157,13 +157,13 @@ export class HoverProvider implements vscode.HoverProvider{
         // 自身のファイル内の定義、定理、ラベルを参照する場合
         // 「Def10」「Th1」「 A1」「,A2」等を正規表現で取得する
         if (wordRange = document.getWordRangeAtPosition(
-                        position,/(Def\d+|Th\d+|( |,)A\d+)/)){
+                        position,/(Def\d+|Th\d+|( |,)A\d+)/) ){
             return returnHover(document, wordRange, position);
         }
         // 外部ファイル（MML）の定義、定理、スキームを参照する場合
         // 「FUNCT_2:def 1」「FINSUB_1:13」「XBOOLE_0:sch 1」等を正規表現で取得する
         else if (wordRange = document.getWordRangeAtPosition(
-                            position,/(\w+:def \d+|\w+:\d+|\w+:sch \d+)/)){
+                            position,/(\w+:def \d+|\w+:\d+|\w+:sch \d+)/) ){
             return returnMMLHover(document,wordRange);
         }
         // ホバー対象のキーワードでない場合

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,85 +1,149 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-// n番目のsearchStringの位置を返す関数
-function getNthKeywordIndex(text:string,keyword:string,n:number){
-    var index = -1;
-    for(let i = 0; i < n; i++){
-        index = text.indexOf(keyword,index+1);
-    }
-    return index;
-}
 
-function returnHover(document:vscode.TextDocument, wordRange:vscode.Range, position:vscode.Position){
-    try{
-        let startIndex = 0,endIndex = 0;
-        // TODO:非同期へ修正
-
-        let referenceText = "" + fs.readFileSync(document.fileName);
-        let word = document.getText(wordRange);
-        // definitionを参照する場合
-        if(word.indexOf('Def') > -1){
-            // TODO:+1の修正、見直し
-            startIndex = getNthKeywordIndex(referenceText, 'definition', Number(word.slice('Def'.length))+1);
-            endIndex = startIndex + referenceText.slice(startIndex).search(/\nend;/g) + '\nend;'.length;
+// n番目のkeywordの位置を返す関数
+function getNthKeywordIndex(text:string,keyword:RegExp,n:number){
+    let absoluteIndex = -1;
+    for (let i = 0; i < n; i++){
+        let deltaIndex = text.search(keyword);
+        if (deltaIndex !== -1){
+            absoluteIndex +=  deltaIndex + 1;
+            text = text.slice(deltaIndex+1);
         }
-        // theoremを参照する場合
-        else if(word.indexOf('Th') > -1){
-            startIndex = getNthKeywordIndex(referenceText, 'theorem', Number(word.slice('Th'.length))+1);
-            endIndex = startIndex + referenceText.slice(startIndex).search(/(\nproof|;)/g) + '\n'.length;
-        }
-        // ラベルを参照する場合
         else{
-            // ホバー中の現在の行までの文字数を取得
-            let number = getNthKeywordIndex(referenceText,'\n', position.line);
-            // 直前のラベルの定義元の位置を取得
-            startIndex = referenceText.lastIndexOf(word.replace(/( |,)/, '')+':', number);
-            endIndex = startIndex + referenceText.slice(startIndex).indexOf('\n');
+            return -1;
         }
-        let markedString = {language:"Mizar", value: referenceText.slice(startIndex,endIndex)};
-        let hover = new vscode.Hover(markedString, wordRange);
-        return hover;
-
-    }catch(e){
-        return;
     }
+    return absoluteIndex;
 }
 
-function returnMMLHover(document:vscode.TextDocument,wordRange:vscode.Range):vscode.ProviderResult<vscode.Hover>{
+function returnHover(
+    document:vscode.TextDocument,
+    wordRange:vscode.Range,
+    position:vscode.Position
+){
+    let p:Promise<vscode.Hover> = new Promise((resolve,reject) => {
+        let startIndex = 0,endIndex = 0;
+        let hoveredWord = document.getText(wordRange);
+        try{
+            fs.readFile(document.fileName,'utf8',(err,referenceText) => {
+                // definitionを参照する場合
+                if(hoveredWord.indexOf('Def') > -1){
+                    // TODO:+1の修正、見直し
+                    startIndex = getNthKeywordIndex(
+                        referenceText,
+                        /definition( |\r\n)/, 
+                        Number(hoveredWord.slice('Def'.length))
+                    );
+                    endIndex = startIndex 
+                            + referenceText.slice(startIndex).search(/\nend;/g)
+                            + '\nend;'.length;
+                }
+                // theoremを参照する場合
+                else if(hoveredWord.indexOf('Th') > -1){
+                    startIndex = getNthKeywordIndex(
+                        referenceText, 
+                        /theorem( |\r\n)/, 
+                        Number(hoveredWord.slice('Th'.length))
+                    );
+                    endIndex = startIndex 
+                            + referenceText.slice(startIndex).search(/(\nproof|;)/g)
+                            + '\n'.length;
+                }
+                // ラベルを参照する場合
+                else{
+                    // ホバー中の行までの文字数を取得
+                    let number = getNthKeywordIndex(
+                        referenceText,
+                        /\r\n/, 
+                        position.line
+                    );
+                    // 直前のラベルの定義元の位置を取得
+                    startIndex = referenceText.lastIndexOf(
+                        hoveredWord.replace(/( |,)/, '')+':', 
+                        number
+                    );
+                    endIndex = startIndex 
+                            + referenceText.slice(startIndex).indexOf('\n');
+                }
+                let markedString = {
+                    language:"Mizar", 
+                    value: referenceText.slice(startIndex,endIndex)
+                };
+                resolve(new vscode.Hover(markedString, wordRange));
+            });
+        }catch(e){
+            reject(e);
+        }
+    });
+    return p;
+}
+
+function returnMMLHover(
+    document:vscode.TextDocument,
+    wordRange:vscode.Range
+):Promise<vscode.Hover>
+{
     if(process.env.MIZFILES === undefined){
         vscode.window.showErrorMessage('error!');
-        return;
+        return new Promise((resolve,reject) => {
+            reject(new Error('You have to set environment variable "MIZFILES"'));
+        });
     }
-    try{
-        let mmlPath = path.join(process.env.MIZFILES,'mml');
-        let word = document.getText(wordRange);
-        let [fileName, referenceWord] = word.split(':');
-        fileName = path.join(mmlPath,fileName.toLowerCase() + '.miz');
-        let startIndex = 0,endIndex = 0;
-        // TODO:非同期へ修正
-        let referenceText = "" + fs.readFileSync(fileName)
-            // definitionを参照する場合
-            if(referenceWord.indexOf('def') > -1){
-                startIndex = getNthKeywordIndex(referenceText, 'definition', Number(referenceWord.slice('def '.length))+1);
-                endIndex = startIndex + referenceText.slice(startIndex).search(/\nend;/g) + '\nend;'.length;
-            }
-            // schemeを参照する場合
-            else if(referenceWord.indexOf('sch') > -1){
-                startIndex = getNthKeywordIndex(referenceText, 'scheme', Number(referenceWord.slice('sch '.length))+1);
-                endIndex = startIndex + referenceText.slice(startIndex).search(/\nend;/g) + '\nend;'.length;
-            }
-            // theoremを参照する場合
-            else{
-                startIndex = getNthKeywordIndex(referenceText, 'theorem', Number(referenceWord)+1);
-                endIndex = startIndex + referenceText.slice(startIndex).search(/(\nproof|;)/g) + '\n'.length;
-            }
-            let markedString = {language:"Mizar", value: referenceText.slice(startIndex,endIndex)};
-            let hover = new vscode.Hover(markedString, wordRange);
-            return hover;
-    }catch(e){
-        console.log(e);
-        return;
-    }
+    let mmlPath = path.join(process.env.MIZFILES,'mml');
+    let hoveredWord = document.getText(wordRange);
+    let [fileName, referenceWord] = hoveredWord.split(':');
+    fileName = path.join(mmlPath,fileName.toLowerCase() + '.miz');
+    let startIndex = 0,endIndex = 0;
+
+    let p:Promise<vscode.Hover> = new Promise ( (resolve, reject)=> {
+        try{
+            fs.readFile(fileName,'utf8', (err,referenceText) => {
+                // definitionを参照する場合
+                if(referenceWord.indexOf('def') > -1){
+                    startIndex = getNthKeywordIndex(
+                        referenceText, 
+                        /definition( |\r\n)/, 
+                        Number(referenceWord.slice('def '.length))
+                    );
+                    endIndex = startIndex 
+                        + referenceText.slice(startIndex).search(/\nend;/g) 
+                        + '\nend;'.length;
+                }
+                // schemeを参照する場合
+                else if(referenceWord.indexOf('sch') > -1){
+                    startIndex = getNthKeywordIndex(
+                        referenceText, 
+                        /scheme( |\r\n)/, 
+                        Number(referenceWord.slice('sch '.length))
+                    );
+                    endIndex = startIndex 
+                        + referenceText.slice(startIndex).search(/\nend;/g) 
+                        + '\nend;'.length;
+                }
+                // theoremを参照する場合
+                else{
+                    startIndex = getNthKeywordIndex(
+                        referenceText, 
+                        /theorem( |\r\n)/, 
+                        Number(referenceWord)
+                    );
+                    endIndex = startIndex 
+                            + referenceText.slice(startIndex).search(/(\nproof|;)/g)
+                            + '\n'.length;
+                }
+                let markedString = {
+                    language:"Mizar", 
+                    value: referenceText.slice(startIndex,endIndex)
+                };
+                resolve(new vscode.Hover(markedString, wordRange));
+            });
+        }catch(e){
+            reject(e);
+        }
+    });
+    return p;
 }
 
 export class HoverProvider implements vscode.HoverProvider{
@@ -89,17 +153,17 @@ export class HoverProvider implements vscode.HoverProvider{
         position: vscode.Position,
         token:vscode.CancellationToken
     ):vscode.ProviderResult<vscode.Hover>{
-        // ホバーの範囲を正規表現により取得
         let wordRange:vscode.Range | undefined;
-
         // 自身のファイル内の定義、定理、ラベルを参照する場合
         // 「Def10」「Th1」「 A1」「,A2」等を正規表現で取得する
-        if (wordRange = document.getWordRangeAtPosition(position,/(Def\d+|Th\d+|( |,)A\d+)/)){
+        if (wordRange = document.getWordRangeAtPosition(
+                        position,/(Def\d+|Th\d+|( |,)A\d+)/)){
             return returnHover(document, wordRange, position);
         }
         // 外部ファイル（MML）の定義、定理、スキームを参照する場合
         // 「FUNCT_2:def 1」「FINSUB_1:13」「XBOOLE_0:sch 1」等を正規表現で取得する
-        else if (wordRange = document.getWordRangeAtPosition(position,/(\w+:def \d+|\w+:\d+|\w+:sch \d+)/)){
+        else if (wordRange = document.getWordRangeAtPosition(
+                            position,/(\w+:def \d+|\w+:\d+|\w+:sch \d+)/)){
             return returnMMLHover(document,wordRange);
         }
         // ホバー対象のキーワードでない場合


### PR DESCRIPTION
参照している定理・定義・スキーム・ラベルに対するホバー機能を実装しました。
「自身のファイルから定理・定義・ラベルを参照する場合」と「外部の定理・定義を参照している場合」の2パターンがあるため、それぞれの処理として「returnHover」と「returnMMLHover」という2つの関数を作成しました。
現状ラベルのホバーでは、ホバーされたラベル名と一致する直前の定義を参照する処理になっています。