### PR TITLE
Close #40 Mizarコマンドの表示名の変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mizar-extension",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,47 +32,47 @@
             {
                 "category": "Mizar",
                 "command": "mizar-verify",
-                "title": "mizar-verify"
+                "title": "Mizar Compile"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-verify2",
-                "title": "mizar-verify2"
+                "title": "Run Mizar"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-irrths",
-                "title": "mizar-irrths"
+                "title": "Irrelevant Theorems"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-relinfer",
-                "title": "mizar-relinfer"
+                "title": "Irrelevant Inferences"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-trivdemo",
-                "title": "mizar-trivdemo"
+                "title": "Trivial Proofs"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-reliters",
-                "title": "mizar-reliters"
+                "title": "Irrelevant Iterative Steps"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-relprem",
-                "title": "mizar-relprem"
+                "title": "Irrelevant Premises"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-irrvoc",
-                "title": "mizar-irrvoc"
+                "title": "Irrelevant Vocabularies"
             },
             {
                 "category": "Mizar",
                 "command": "mizar-inacc",
-                "title": "mizar-inacc"
+                "title": "Inaccessible Items"
             }
         ],
         "languages": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mizar-extension",
     "displayName": "Mizar extension",
     "description": "An extension for VS Code which provides support for the Mizar language.",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "publisher": "fpsbpkm",
     "engines": {
         "vscode": "^1.38.0"


### PR DESCRIPTION
Mizarコマンドの表示名をEmacs for Mizarの表示に合わせました．

* mizar-verify -> Mizar Compile
* mizar-verify2 -> Run Mizar
* mizar-irrths -> Irrelevant Theorems
* mizar-relinfer -> Irrelevant Inferences
* mizar-trivdemo -> Trivial Proofs
* mizar-reliters -> Irrelevant Iterative Steps
* mizar-relprem -> Irrelevant Premises
* mizar-irrvoc -> Irrelevant Vocabularie
* mizar-inacc -> Inaccessible Items