### PR TITLE
他OSで実行できるよう，コマンドを絶対パスで指定しないように修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "mizar-extension",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mizar-extension",
     "displayName": "Mizar extension",
     "description": "An extension for VS Code which provides support for the Mizar language.",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "publisher": "fpsbpkm",
     "engines": {
         "vscode": "^1.38.0"

--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -24,9 +24,8 @@ export async function mizar_verify(
     command:string="verifier"
 ):Promise<string>
 {
-    // コマンドを絶対パスにしている
-    command = path.join(String(mizfiles) ,command);
-    let makeenv = path.join(String(mizfiles),Makeenv);
+    // Mizarコマンドのパスが通っていることを前提とする
+    let makeenv = Makeenv;
     // 拡張子を確認し、mizarファイルでなければエラーを示して終了
     if (path.extname(fileName) !== '.miz'){
         vscode.window.showErrorMessage('Not currently in .miz file!!');


### PR DESCRIPTION
以前までMIZFILESを利用して，コマンドを絶対パスで指定していましたが，Windows以外ではうまくいかない状態でした．
そのため，Mizarコマンドのディレクトリにパスが通っていることを前提として，修正しました．
調べたところ，macOSでは以下のような構造になるようです．
* /usr/local/bin（Mizarコマンドが配置される）
* /usr/local/share/mizar（MIZFILESが設定されるディレクトリ，MMLやAbstrなどがある）
* /usr/local/doc/mizar