### PR TITLE
コマンドが実行できなくなる不具合の修正

### DIFF
--- a/src/mizarFunctions.ts
+++ b/src/mizarFunctions.ts
@@ -54,6 +54,7 @@ export async function mizar_verify(
     // 非同期処理から実行結果を得るため、Promiseを利用している
     let result:Promise<string> = new Promise((resolve) => {
         makeenvProcess.on('close', () => {
+            runningCmd['process'] = null;
             if (!isMakeenvSuccess){
                 resolve('makeenv error');
                 return;


### PR DESCRIPTION
前回のアップデートによって，
* コマンドが実行できなくなるバグ
* 問題パネルの診断メッセージが1つしか表示されないバグ

が発生してしまいました．

以下，原因と修正内容です．

* コマンドが実行できなくなるバグ
    * 実行中のコマンドをrunningCmd['process']に保存し，コマンドが終了すればnullにしていましたが，makeenvでエラーがあった場合にnullの割り当てができていませんでした．
    makeenvの終了後に，nullを割り当てる処理を追加しました．
    
* 問題パネルの診断メッセージが1つしか表示されないバグ
    * 関数の処理内容を見誤ってしまい，リストに診断メッセージを1つ追加(push)する関数内で，メッセージリストを初期化してしまっていました．